### PR TITLE
bugfix: regex in IRC class to match PING message 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,12 @@ $ git config --global user.name 'your name'
 $ git config --global user.email 'your email'
 ```
 
-* Fork Deer to your Github account by clicking the [Fork](https://github.com/nxf7/deer/fork)
+* Fork Deer to your Github account by clicking the [Fork](https://github.com/blocr/deer/fork)
 button
 
 * Clone the main Deer repository locally (through https or preferably ssh)
 ```
-$ git clone https://github.com/nxf7/deer
+$ git clone https://github.com/blocr/deer
 $ cd deer
 ```
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,9 +5,9 @@ author = The Habibis
 description = A very evil general-purpose IRC bot
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/nxf7/deer
+url = https://github.com/blocr/deer
 project_urls =
-    Bug Tracker = https://github.com/nxf7/deer/issues
+    Bug Tracker = https://github.com/blocr/deer/issues
 classifiers =
     Programming Language :: Python :: 3
     License :: OSI Approved :: MIT License

--- a/src/deer/irc.py
+++ b/src/deer/irc.py
@@ -100,8 +100,17 @@ class IRC:
     def parse_worker(self):
         while True:
             msg = self.socket.getq()
+
+            # spec: https://modern.ircdocs.horse/#message-format
             parsed_msg = re.match(
-                r"(?P<prefix>\S+)?(?P<cmd>\S+)(?P<params>.*)\r\n", msg
+                r"""
+                (?P<tag>@\S+ )?
+                (?P<source>:\S+ )?
+                (?P<cmd>\S+ )
+                (?P<params>.*)
+                \r\n""",
+                msg,
+                re.VERBOSE,
             )
 
             if parsed_msg:


### PR DESCRIPTION
### Bug 
IRC client receives `PING :calcium.libera.chat` but does not respond

### Cause
irc.py:104 `r"(?P<prefix>\S+)?(?P<cmd>\S+)(?P<params>.*)\r\n", msg`
The `prefix` group matches the `PING` keyword instead of `cmd`

### Fix
Prepend `prefix` regex with ":"
Split `prefix` into `tag` and `source` to comply with [modern spec](https://modern.ircdocs.horse/#message-format)

###  Other
 Update upstream username
