### PR TITLE
fix: escape space char in verbose regex

### DIFF
--- a/src/deer/irc.py
+++ b/src/deer/irc.py
@@ -104,9 +104,9 @@ class IRC:
             # spec: https://modern.ircdocs.horse/#message-format
             parsed_msg = re.match(
                 r"""
-                (?P<tag>@\S+ )?
-                (?P<source>:\S+ )?
-                (?P<cmd>\S+ )
+                (?P<tag>@\S+\s)?
+                (?P<source>:\S+\s)?
+                (?P<cmd>\S+\s)
                 (?P<params>.*)
                 \r\n""",
                 msg,


### PR DESCRIPTION
python gobbles up those spaces otherwise and bad things happen